### PR TITLE
chore: add Python packaging groundwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,18 @@ This opensource project is based on the [Apache 2.0](./LICENSE) license.
 
 ### Installation
 
-Clone this repository:
+Clone this repository and install it in editable mode:
 
 ```
 git clone https://github.com/campable-io/braille-camp.git
 cd braille-camp
+python -m pip install -e .
 ```
 
 Import the `convert_latex_to_braille` function. This takes a `LaTeX` input which transcribes to braille notation:
 
 ```
-from .algorithm import convert_latex_to_braille
+from algorithm import convert_latex_to_braille
 
 problem = """다음 극한값을 구하여라.
 (1) \( \lim _{n \rightarrow \infty} \frac{(n+2)(3n-5)}{(2n+1)(n-2)} \)

--- a/algorithm/__init__.py
+++ b/algorithm/__init__.py
@@ -1,0 +1,5 @@
+"""Public API for the Braille Camp transcription algorithm."""
+
+from .braille_algorithm import convert_latex_to_braille
+
+__all__ = ["convert_latex_to_braille"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "braille-camp"
+version = "0.1.0"
+description = "Convert LaTeX mathematical notation to Korean Math Braille."
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "Apache-2.0" }
+authors = [
+  { name = "CampAble" }
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Education",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Topic :: Education",
+  "Topic :: Scientific/Engineering :: Mathematics",
+]
+
+[project.urls]
+Homepage = "https://braille.campable.io"
+Repository = "https://github.com/campable-io/braille-camp"
+
+[tool.setuptools.packages.find]
+include = ["algorithm*"]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,20 @@
+import contextlib
+import io
+import unittest
+
+from algorithm import convert_latex_to_braille
+
+
+class ConvertLatexToBrailleSmokeTest(unittest.TestCase):
+    def test_convert_latex_to_braille_returns_non_empty_string(self):
+        stdout = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout):
+            result = convert_latex_to_braille(r"\(x+1\)")
+
+        self.assertIsInstance(result, str)
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds a small Python packaging groundwork for Braille Camp without changing the transcription algorithm behavior.

Changes included:

- add `pyproject.toml` with a minimal setuptools-based package configuration
- expose `convert_latex_to_braille` from `algorithm/__init__.py`
- update the README quick start to include `python -m pip install -e .`
- update the README import example to use `from algorithm import convert_latex_to_braille`
- add a minimal smoke test for the public import path and return type

## Motivation

This follows up on #2. The goal is to make the existing Python algorithm easier to install locally and reuse from other Python projects, while keeping this first PR intentionally small and non-invasive.

## Scope

This PR intentionally does not change:

- transcription algorithm behavior
- output format
- math braille rules or mappings
- package/module directory structure beyond exposing the existing public function

## Verification

Ran locally:

```bash
python3 -m compileall -q .
python3 -m unittest discover -s tests -v
```

Also verified editable installation in a temporary virtual environment:

```bash
python -m pip install -e .
python - <<'PY'
from algorithm import convert_latex_to_braille
value = convert_latex_to_braille(r"\\(x+1\\)")
assert isinstance(value, str)
assert value
PY
```

Note: the existing code currently emits some `SyntaxWarning` / `FutureWarning` messages during import or execution. I left those unchanged to keep this PR focused only on packaging groundwork.